### PR TITLE
修复 获取Cookies 函数异常

### DIFF
--- a/src/service/V11/action/common.ts
+++ b/src/service/V11/action/common.ts
@@ -54,7 +54,7 @@ export class CommonAction {
      * @param domain {string} 域名
      */
     getCookies(this: V11, domain: string) {
-        return this.adapter.call["getCookies"]([domain]);
+        return this.adapter.call(this.oneBot.uin, "V11", "getCookies", [domain])
     }
 
     /**


### PR DESCRIPTION
>原有的 `return this.adapter.call["getcookies"]([domain])` 方法会导致`icqq`无法正确获取Cookies 故替换为此方法使其可以正确获取