### PR TITLE
fix(onebot-v12): 修复正向 WS connect 与反向 WS 心跳

### DIFF
--- a/protocols/onebot-v12/protocol/src/index.ts
+++ b/protocols/onebot-v12/protocol/src/index.ts
@@ -59,10 +59,10 @@ export class OneBotV12Protocol extends Protocol<"v12", OneBotV12Config.Config> {
             this.config.ws_reverse.forEach(url => this.startWsReverse(url));
         }
 
-        // Send connect meta event
-        this.dispatchMetaEvent("connect", {
-            version: this.getVersionInfo(),
-        });
+        // 正向/反向 WebSocket 均需要心跳，不能只在 startWebSocket 里启动
+        if (this.config.use_ws || this.config.ws_reverse?.length > 0) {
+            this.setupHeartbeat();
+        }
     }
 
     /**
@@ -631,6 +631,23 @@ export class OneBotV12Protocol extends Protocol<"v12", OneBotV12Config.Config> {
     }
 
     /**
+     * 启动心跳定时器（每个协议实例仅一次）
+     */
+    private setupHeartbeat(): void {
+        if (!this.config.heartbeat_interval || this.heartbeatTimer) {
+            return;
+        }
+
+        // 配置为秒，转换为毫秒；至少 1 秒
+        const intervalMs = Math.max(Number(this.config.heartbeat_interval) || 1, 1) * 1000;
+        this.heartbeatTimer = setInterval(() => {
+            this.dispatchMetaEvent("heartbeat", {
+                interval: intervalMs,
+            });
+        }, intervalMs);
+    }
+
+    /**
      * Dispatch meta event
      */
     private dispatchMetaEvent(detailType: string, extra: any = {}): void {
@@ -713,18 +730,18 @@ export class OneBotV12Protocol extends Protocol<"v12", OneBotV12Config.Config> {
 
             this.logger.info(`WebSocket client connected: ${this.path}`);
 
-            // Send connect meta event
-            this.dispatchMetaEvent("connect", {
-                version: this.getVersionInfo(),
-            });
-
-            // Listen for dispatch events and send to client
+            // 必须先注册监听器，再发送 connect，否则客户端收不到
             const onDispatch = (data: string) => {
                 if (ws.readyState === WebSocket.OPEN) {
                     ws.send(data);
                 }
             };
             this.on("dispatch", onDispatch);
+
+            // Send connect meta event
+            this.dispatchMetaEvent("connect", {
+                version: this.getVersionInfo(),
+            });
 
             // Handle incoming API calls
             ws.on("message", async (data) => {
@@ -757,17 +774,6 @@ export class OneBotV12Protocol extends Protocol<"v12", OneBotV12Config.Config> {
                 this.logger.error("WebSocket error:", error);
             });
         });
-
-        // Setup heartbeat (only once per protocol instance)
-        if (this.config.heartbeat_interval && !this.heartbeatTimer) {
-            // 配置为秒，转换为毫秒；至少 1 秒
-            const intervalMs = Math.max(Number(this.config.heartbeat_interval) || 1, 1) * 1000;
-            this.heartbeatTimer = setInterval(() => {
-                this.dispatchMetaEvent("heartbeat", {
-                    interval: intervalMs,
-                });
-            }, intervalMs);
-        }
 
         this.logger.info(`WebSocket server listening on ${this.path}`);
     }


### PR DESCRIPTION
## Summary

- 修复 Issue #211：正向 WebSocket 客户端收不到 `connect` 元事件（NoneBot2 报 `Missing connect meta event`）
- 修复反向 WebSocket 仅配置 `ws_reverse` 时收不到 `heartbeat` 的问题
- 移除 `start()` 中无效的提前广播 `connect`

## 根因

1. **正向 WS**：`dispatchMetaEvent("connect")` 在注册 `dispatch` 监听器之前执行，事件丢失
2. **反向 WS**：心跳定时器只在 `startWebSocket()` 内启动，`use_ws: false` 时不会触发

## Test plan

- [ ] 正向 WS 连接后立即收到 `type=meta, detail_type=connect`
- [ ] 正向 WS 持续收到 `heartbeat`
- [ ] 仅 `ws_reverse` 配置时也能收到 `heartbeat`
- [ ] NoneBot2 连接 `ws://localhost:6727/kook/xxx/onebot/v12` 不再报 Missing connect meta event

Fixes #211


Made with [Cursor](https://cursor.com)